### PR TITLE
Add CLI scene search command with structured output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ This repository uses Codex agents. Use this file to build a lightweight memory f
 - Keep the newest bullets at the top of each list.
 
 ## Log
+- Added a dedicated `hazardwatch` CLI `search` command with human/JSON output, plus README usage docs and CLI tests.
 - Created `AGENTS.md` with logging instructions.
 
 ## Ideas
+- Add additional subcommands like `plan`, `sources`, and `export` to make the tool feel closer to Codex CLI workflows.
 - 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ export PLANET_API_KEY=...   # optional
 # 5  Run the first demo
 codex "Map flood damage for Cedar Key after Idalia"
 
+
+CLI usage
+---------
+Run the local CLI directly with Python:
+
+```bash
+python -m hazardwatch.cli search path/to/aoi.geojson 2025-01-01/2025-01-07 --limit 5
+```
+
+Add `--json` for machine-readable output suitable for automation pipelines.
+
 Browser-based STAC search
 -------------------------
 If you prefer not to install Python, open ``web/index.html`` in any modern

--- a/hazardwatch/cli.py
+++ b/hazardwatch/cli.py
@@ -1,0 +1,104 @@
+"""Command-line interface for the HazardWatch prototype."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, List
+
+from .pipeline import run_pipeline
+from .stac_search import DEFAULT_STAC_URL
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI parser."""
+    parser = argparse.ArgumentParser(
+        prog="hazardwatch",
+        description="Codex-style disaster mapping CLI for rapid Sentinel scene discovery.",
+    )
+    parser.add_argument(
+        "--stac-url",
+        default=DEFAULT_STAC_URL,
+        help="STAC API endpoint to query (default: Planetary Computer)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    search_parser = subparsers.add_parser(
+        "search",
+        help="Search for scenes over an AOI and date/date range.",
+    )
+    search_parser.add_argument("aoi", help="Path to AOI GeoJSON file")
+    search_parser.add_argument("date", help="ISO date or date range (YYYY-MM-DD/YYYY-MM-DD)")
+    search_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of results to print",
+    )
+    search_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON output",
+    )
+
+    return parser
+
+
+def _summarize_item(item: Any) -> Dict[str, Any]:
+    item_id = getattr(item, "id", None)
+    collection_id = getattr(item, "collection_id", None)
+    properties = getattr(item, "properties", {}) or {}
+
+    if item_id is None and isinstance(item, dict):
+        item_id = item.get("id")
+        properties = item.get("properties", properties)
+        collection_id = item.get("collection") or item.get("collection_id")
+
+    return {
+        "id": item_id,
+        "collection": collection_id,
+        "datetime": properties.get("datetime"),
+    }
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    items = run_pipeline(args.aoi, args.date, stac_url=args.stac_url)
+    summaries: List[Dict[str, Any]] = [_summarize_item(item) for item in items[: args.limit]]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "count": len(items),
+                    "showing": len(summaries),
+                    "results": summaries,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"Found {len(items)} scene(s); showing {len(summaries)}")
+        for idx, summary in enumerate(summaries, start=1):
+            print(
+                f"{idx}. {summary.get('id')} "
+                f"[{summary.get('collection')}] "
+                f"{summary.get('datetime')}"
+            )
+
+    return 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "search":
+        return cmd_search(args)
+
+    parser.error(f"Unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import json
+
+import hazardwatch.cli as cli
+
+
+class FakeItem:
+    def __init__(self, item_id, collection_id, dt):
+        self.id = item_id
+        self.collection_id = collection_id
+        self.properties = {"datetime": dt}
+
+
+def test_search_human_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli,
+        "run_pipeline",
+        lambda aoi, date, stac_url: [
+            FakeItem("A", "sentinel-2-l2a", "2025-01-01T00:00:00Z"),
+            FakeItem("B", "sentinel-1-grd", "2025-01-02T00:00:00Z"),
+        ],
+    )
+
+    rc = cli.main(["search", "aoi.geojson", "2025-01-01/2025-01-05", "--limit", "1"])
+
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "Found 2 scene(s); showing 1" in output
+    assert "1. A [sentinel-2-l2a]" in output
+
+
+def test_search_json_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli,
+        "run_pipeline",
+        lambda aoi, date, stac_url: [
+            {"id": "item-1", "collection": "sentinel-1-grd", "properties": {"datetime": "2025-01-01T00:00:00Z"}}
+        ],
+    )
+
+    rc = cli.main(["search", "aoi.geojson", "2025-01-01", "--json"])
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert rc == 0
+    assert payload["count"] == 1
+    assert payload["results"][0]["id"] == "item-1"


### PR DESCRIPTION
### Motivation
- Provide a small, extensible command-line interface so the project can be used like a Codex-style disaster mapping CLI for quick scene discovery. 
- Support both human-readable and machine-readable outputs to make the tool suitable for interactive use and automation pipelines. 

### Description
- Add a new `hazardwatch.cli` module implementing an argparse-based CLI with a `search` subcommand and a global `--stac-url` override. 
- Implement result limiting via `--limit` and structured JSON output via `--json`, and normalize STAC item/dict fields in `_summarize_item`. 
- Add unit tests in `tests/test_cli.py` that monkeypatch `run_pipeline` to verify human and JSON output modes. 
- Document CLI usage in `README.md` and update `AGENTS.md` log/ideas per repository guidance. 

### Testing
- Run `pytest -q` which executed the test suite and reported `5 passed`.
- The new CLI tests (`tests/test_cli.py`) run as part of the suite and passed in the final run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69891837c34c8327b3ee52de229b2d71)