### PR TITLE
Add mission scaffolding CLI for first-responder hazard mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ This repository uses Codex agents. Use this file to build a lightweight memory f
 - Keep the newest bullets at the top of each list.
 
 ## Log
+- Added `hazardwatch/mission_scaffold.py` plus tests and README usage for first-responder mission packet + Codex prompt generation.
 - Created `AGENTS.md` with logging instructions.
 
 ## Ideas
+- Add optional `--packet-template` presets (flood/wildfire/hurricane) so responders can start with one command.
 - 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ export PLANET_API_KEY=...   # optional
 # 5  Run the first demo
 codex "Map flood damage for Cedar Key after Idalia"
 
+
+Mission scaffolding CLI
+-----------------------
+Generate a structured first-responder mission packet and a Codex-ready prompt:
+
+```bash
+python -m hazardwatch.mission_scaffold \
+  --incident-name "Hurricane Idalia" \
+  --hazard-type "Flood" \
+  --location "Suwannee County, FL" \
+  --date-range "2024-08-30/2024-09-02" \
+  --priority-layer "Flood extent" \
+  --priority-layer "Road blockage" \
+  --requester "Suwannee County EOC" \
+  --notes "Prioritize hospitals and shelters"
+```
+
+This writes `output/mission_packet.json` and prints a reusable prompt that can be passed to Codex CLI for automated workflow generation.
+
 Browser-based STAC search
 -------------------------
 If you prefer not to install Python, open ``web/index.html`` in any modern

--- a/hazardwatch/mission_scaffold.py
+++ b/hazardwatch/mission_scaffold.py
@@ -1,0 +1,120 @@
+"""CLI scaffolding for first-responder hazard mapping missions.
+
+This module helps teams turn incident details into a structured mission packet
+and a reusable Codex CLI prompt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class MissionPacket:
+    """Structured information needed to run a first-response mapping mission."""
+
+    incident_name: str
+    hazard_type: str
+    location: str
+    date_range: str
+    priority_layers: List[str]
+    requester: str
+    notes: str = ""
+
+
+def create_mission_packet(
+    incident_name: str,
+    hazard_type: str,
+    location: str,
+    date_range: str,
+    priority_layers: List[str],
+    requester: str,
+    notes: str = "",
+) -> MissionPacket:
+    """Create a mission packet with normalized text fields."""
+
+    normalized_layers = [layer.strip() for layer in priority_layers if layer.strip()]
+    if not normalized_layers:
+        raise ValueError("priority_layers must include at least one layer")
+
+    return MissionPacket(
+        incident_name=incident_name.strip(),
+        hazard_type=hazard_type.strip(),
+        location=location.strip(),
+        date_range=date_range.strip(),
+        priority_layers=normalized_layers,
+        requester=requester.strip(),
+        notes=notes.strip(),
+    )
+
+
+def build_codex_prompt(packet: MissionPacket) -> str:
+    """Build a Codex CLI-ready prompt from a mission packet."""
+
+    layer_list = ", ".join(packet.priority_layers)
+    notes = packet.notes if packet.notes else "No additional notes provided."
+
+    return (
+        "You are supporting first responders with rapid geospatial analysis.\n"
+        "Create or update a reproducible hazard mapping pipeline in this repository.\n\n"
+        f"Incident: {packet.incident_name}\n"
+        f"Hazard type: {packet.hazard_type}\n"
+        f"Location: {packet.location}\n"
+        f"Date range: {packet.date_range}\n"
+        f"Priority layers: {layer_list}\n"
+        f"Requester: {packet.requester}\n"
+        f"Field notes: {notes}\n\n"
+        "Execution requirements:\n"
+        "1) Use Sentinel data first, then upgrade to commercial imagery only if API keys exist.\n"
+        "2) Export outputs as GeoPackage and Cloud-Optimized GeoTIFF.\n"
+        "3) Produce a lightweight web viewer for responders.\n"
+        "4) Add or update tests for any new logic.\n"
+    )
+
+
+def save_mission_packet(packet: MissionPacket, output_path: str) -> Path:
+    """Save mission packet JSON to disk and return the final path."""
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(packet), indent=2), encoding="utf-8")
+    return path
+
+
+def main() -> None:
+    """Command-line helper for generating mission packets and Codex prompts."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate first-responder mission scaffolding")
+    parser.add_argument("--incident-name", required=True, help="Incident name")
+    parser.add_argument("--hazard-type", required=True, help="Hazard type")
+    parser.add_argument("--location", required=True, help="Location description")
+    parser.add_argument("--date-range", required=True, help="Date or date range")
+    parser.add_argument("--priority-layer", action="append", required=True, help="Layer priority")
+    parser.add_argument("--requester", required=True, help="Requesting team")
+    parser.add_argument("--notes", default="", help="Optional notes")
+    parser.add_argument("--packet-out", default="output/mission_packet.json", help="JSON output path")
+
+    args = parser.parse_args()
+    packet = create_mission_packet(
+        incident_name=args.incident_name,
+        hazard_type=args.hazard_type,
+        location=args.location,
+        date_range=args.date_range,
+        priority_layers=args.priority_layer,
+        requester=args.requester,
+        notes=args.notes,
+    )
+
+    saved_path = save_mission_packet(packet, args.packet_out)
+    print(f"Saved mission packet: {saved_path}")
+    print("\nCodex prompt:\n")
+    print(build_codex_prompt(packet))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mission_scaffold.py
+++ b/tests/test_mission_scaffold.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import json
+
+import pytest
+
+from hazardwatch.mission_scaffold import (
+    MissionPacket,
+    build_codex_prompt,
+    create_mission_packet,
+    save_mission_packet,
+)
+
+
+def test_create_mission_packet_normalizes_layers_and_fields():
+    packet = create_mission_packet(
+        incident_name="  Idalia  ",
+        hazard_type=" flood ",
+        location=" Suwannee County, FL ",
+        date_range=" 2024-08-30/2024-09-02 ",
+        priority_layers=[" flood extent ", "", " road blockage "],
+        requester=" County EOC ",
+        notes="  prioritize hospitals  ",
+    )
+
+    assert packet == MissionPacket(
+        incident_name="Idalia",
+        hazard_type="flood",
+        location="Suwannee County, FL",
+        date_range="2024-08-30/2024-09-02",
+        priority_layers=["flood extent", "road blockage"],
+        requester="County EOC",
+        notes="prioritize hospitals",
+    )
+
+
+def test_create_mission_packet_requires_layer():
+    with pytest.raises(ValueError, match="priority_layers"):
+        create_mission_packet(
+            incident_name="Incident",
+            hazard_type="wildfire",
+            location="Somewhere",
+            date_range="2024-01-01",
+            priority_layers=["   ", ""],
+            requester="Requester",
+        )
+
+
+def test_build_codex_prompt_includes_key_sections():
+    packet = MissionPacket(
+        incident_name="Idalia",
+        hazard_type="flood",
+        location="Suwannee County, FL",
+        date_range="2024-08-30/2024-09-02",
+        priority_layers=["flood extent", "damaged structures"],
+        requester="County EOC",
+        notes="",
+    )
+
+    prompt = build_codex_prompt(packet)
+
+    assert "Incident: Idalia" in prompt
+    assert "Priority layers: flood extent, damaged structures" in prompt
+    assert "No additional notes provided." in prompt
+    assert "Use Sentinel data first" in prompt
+
+
+def test_save_mission_packet(tmp_path):
+    packet = MissionPacket(
+        incident_name="Idalia",
+        hazard_type="flood",
+        location="Suwannee County, FL",
+        date_range="2024-08-30/2024-09-02",
+        priority_layers=["flood extent"],
+        requester="County EOC",
+        notes="",
+    )
+
+    output = tmp_path / "packet.json"
+    saved = save_mission_packet(packet, str(output))
+
+    assert saved == output
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["incident_name"] == "Idalia"
+    assert data["priority_layers"] == ["flood extent"]


### PR DESCRIPTION
### Motivation
- Provide a small CLI to convert natural-language incident intake into a structured mission packet and a reusable Codex CLI prompt so first responders can quickly spin up reproducible mapping workflows.
- Make it easy to persist mission specifications (JSON) and enforce minimal validation so downstream Codex workflow generation and tests are simpler and safer.

### Description
- Add `hazardwatch/mission_scaffold.py` which defines a `MissionPacket` dataclass and functions `create_mission_packet`, `build_codex_prompt`, `save_mission_packet`, and a `main` CLI entrypoint.
- Add `tests/test_mission_scaffold.py` with unit tests that verify normalization, required-layer validation, prompt content, and JSON output persistence.
- Update `README.md` with a usage example showing how to run the mission scaffolding CLI and update `AGENTS.md` with a log entry and an ideas line per repository guidance.
- Commit the new module, tests, and documentation updates so the scaffolding integrates with the existing repo structure.

### Testing
- Running `pytest -q` initially failed during collection due to an import path issue in the new test, which was addressed by adding the repository root to `sys.path` in the test file.
- After the import-path fix, running `pytest -q` returned success with `7 passed`, covering the new tests plus the existing test suite (normalization, validation, prompt content, and JSON output assertions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b586a5da9c8327b63d4689d545d3c2)