### PR TITLE
Improve CLI UX and add terminal install packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,11 @@ This repository uses Codex agents. Use this file to build a lightweight memory f
 - Keep the newest bullets at the top of each list.
 
 ## Log
+- Improved CLI UX with new `sources`/`plan` subcommands, `--version`, and terminal install packaging via `pyproject.toml`; refreshed README install guidance and CLI tests.
 - Added a dedicated `hazardwatch` CLI `search` command with human/JSON output, plus README usage docs and CLI tests.
 - Created `AGENTS.md` with logging instructions.
 
 ## Ideas
+- Add a `doctor` command that validates Python deps, AOI readability, and STAC connectivity before running a search.
 - Add additional subcommands like `plan`, `sources`, and `export` to make the tool feel closer to Codex CLI workflows.
 - 

--- a/README.md
+++ b/README.md
@@ -54,15 +54,43 @@ export PLANET_API_KEY=...   # optional
 codex "Map flood damage for Cedar Key after Idalia"
 
 
+
+Terminal install
+----------------
+Install HazardWatch as a terminal command so you can run `hazardwatch` directly:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+pip install .
+hazardwatch --help
+```
+
+If you want a global isolated install, use `pipx`:
+
+```bash
+python -m pip install --user pipx
+pipx ensurepath
+pipx install .
+hazardwatch --help
+```
+
 CLI usage
 ---------
 Run the local CLI directly with Python:
 
 ```bash
-python -m hazardwatch.cli search path/to/aoi.geojson 2025-01-01/2025-01-07 --limit 5
+hazardwatch search path/to/aoi.geojson 2025-01-01/2025-01-07 --limit 5
 ```
 
 Add `--json` for machine-readable output suitable for automation pipelines.
+
+Discover supported sources and inspect the workflow plan:
+
+```bash
+hazardwatch sources
+hazardwatch plan
+```
 
 Browser-based STAC search
 -------------------------

--- a/hazardwatch/cli.py
+++ b/hazardwatch/cli.py
@@ -7,7 +7,15 @@ import json
 from typing import Any, Dict, List
 
 from .pipeline import run_pipeline
-from .stac_search import DEFAULT_STAC_URL
+from .stac_search import DEFAULT_STAC_URL, SENTINEL_COLLECTIONS
+
+CLI_VERSION = "0.1.0"
+DEFAULT_PLAN_STEPS = [
+    "Validate AOI geometry and date/date-range input",
+    "Search STAC for Sentinel-1 and Sentinel-2 scenes",
+    "Rank scenes by acquisition datetime",
+    "Emit a concise result table or machine-readable JSON",
+]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -20,6 +28,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--stac-url",
         default=DEFAULT_STAC_URL,
         help="STAC API endpoint to query (default: Planetary Computer)",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {CLI_VERSION}",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -37,6 +50,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="Maximum number of results to print",
     )
     search_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON output",
+    )
+
+    sources_parser = subparsers.add_parser(
+        "sources",
+        help="Show configured imagery sources and STAC endpoint.",
+    )
+    sources_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON output",
+    )
+
+    plan_parser = subparsers.add_parser(
+        "plan",
+        help="Show planned workflow stages for the current HazardWatch CLI.",
+    )
+    plan_parser.add_argument(
         "--json",
         action="store_true",
         help="Print machine-readable JSON output",
@@ -89,12 +122,51 @@ def cmd_search(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sources(args: argparse.Namespace) -> int:
+    payload = {
+        "stac_url": args.stac_url,
+        "collections": SENTINEL_COLLECTIONS,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"STAC endpoint: {payload['stac_url']}")
+        print("Collections:")
+        for collection in payload["collections"]:
+            print(f"- {collection}")
+
+    return 0
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    payload = {
+        "workflow": "scene-discovery",
+        "steps": DEFAULT_PLAN_STEPS,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print("HazardWatch CLI workflow plan:")
+        for idx, step in enumerate(payload["steps"], start=1):
+            print(f"{idx}. {step}")
+
+    return 0
+
+
 def main(argv: List[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
     if args.command == "search":
         return cmd_search(args)
+
+    if args.command == "sources":
+        return cmd_sources(args)
+
+    if args.command == "plan":
+        return cmd_plan(args)
 
     parser.error(f"Unsupported command: {args.command}")
     return 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hazardwatch"
+version = "0.1.0"
+description = "Codex-style disaster mapping CLI for rapid Sentinel scene discovery"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "InstaHazard Map contributors" }]
+license = { text = "MIT" }
+dependencies = [
+  "geopandas>=1.0.1",
+  "pystac-client>=0.8.3",
+]
+
+[project.scripts]
+hazardwatch = "hazardwatch.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["hazardwatch*"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,3 +49,22 @@ def test_search_json_output(monkeypatch, capsys):
     assert rc == 0
     assert payload["count"] == 1
     assert payload["results"][0]["id"] == "item-1"
+
+
+def test_sources_human_output(capsys):
+    rc = cli.main(["sources"])
+
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "STAC endpoint:" in output
+    assert "- sentinel-1-grd" in output
+
+
+def test_plan_json_output(capsys):
+    rc = cli.main(["plan", "--json"])
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert rc == 0
+    assert payload["workflow"] == "scene-discovery"
+    assert len(payload["steps"]) >= 3


### PR DESCRIPTION
### Motivation
- Make the CLI easier to discover and use interactively and in automation by adding high-level introspection and installability.
- Provide a straightforward terminal installation path so users can run `hazardwatch` as a normal console command instead of `python -m`.
- Surface the planned workflow and available imagery sources to aid developer/operator workflows and scripting.

### Description
- Added `sources` and `plan` subcommands and a top-level `--version` flag to the CLI, with human and `--json` output supported (`hazardwatch/cli.py`).
- Implemented `cmd_sources` and `cmd_plan` handlers and kept existing `search` behavior with the same summary output format (`cmd_search` and `_summarize_item`).
- Added `pyproject.toml` with a console script entry `hazardwatch = "hazardwatch.cli:main"` so the package can be installed and the `hazardwatch` command used directly.
- Updated `README.md` with terminal install instructions (`pip install .` and `pipx install .`), added usage examples for the new commands, expanded `tests/test_cli.py` to cover the new subcommands, and appended a log entry and idea in `AGENTS.md`.

### Testing
- Ran `pytest -q` and all tests passed (`7 passed`).
- Performed an editable install with `python -m pip install -e .` which completed successfully.
- Verified the console entrypoint by running `hazardwatch --help` and confirming the new subcommands and `--version` output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58a58ce8c8327b46ba9bf92de15cb)