### PR TITLE
Add IMH startup banner for interactive CLI sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,13 @@ This repository uses Codex agents. Use this file to build a lightweight memory f
 - Keep the newest bullets at the top of each list.
 
 ## Log
+- Added a styled IMH startup banner for interactive CLI sessions, with JSON-safe suppression and `HAZARDWATCH_NO_BANNER` opt-out; expanded CLI tests and README docs.
 - Improved CLI UX with new `sources`/`plan` subcommands, `--version`, and terminal install packaging via `pyproject.toml`; refreshed README install guidance and CLI tests.
 - Added a dedicated `hazardwatch` CLI `search` command with human/JSON output, plus README usage docs and CLI tests.
 - Created `AGENTS.md` with logging instructions.
 
 ## Ideas
+- Add a `--no-banner` CLI flag for one-off suppression without setting environment variables.
 - Add a `doctor` command that validates Python deps, AOI readability, and STAC connectivity before running a search.
 - Add additional subcommands like `plan`, `sources`, and `export` to make the tool feel closer to Codex CLI workflows.
 - 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ hazardwatch search path/to/aoi.geojson 2025-01-01/2025-01-07 --limit 5
 
 Add `--json` for machine-readable output suitable for automation pipelines.
 
+By default, the CLI prints an IMH startup banner in interactive terminals.
+Set `HAZARDWATCH_NO_BANNER=1` to disable it for local scripts or demos.
+
 Discover supported sources and inspect the workflow plan:
 
 ```bash

--- a/hazardwatch/cli.py
+++ b/hazardwatch/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
 from typing import Any, Dict, List
 
 from .pipeline import run_pipeline
@@ -16,6 +18,17 @@ DEFAULT_PLAN_STEPS = [
     "Rank scenes by acquisition datetime",
     "Emit a concise result table or machine-readable JSON",
 ]
+
+IMH_BANNER = r"""
+╔════════════════════════════════════════════════════════════╗
+║      ██╗███╗   ███╗██╗  ██╗   InstaHazard Maps CLI       ║
+║      ██║████╗ ████║██║  ██║   Rapid disaster mapping      ║
+║      ██║██╔████╔██║███████║   Sentinel scene discovery    ║
+║      ██║██║╚██╔╝██║██╔══██║   Stay ready. Move fast.      ║
+║      ██║██║ ╚═╝ ██║██║  ██║                               ║
+║      ╚═╝╚═╝     ╚═╝╚═╝  ╚═╝                               ║
+╚════════════════════════════════════════════════════════════╝
+""".strip("\n")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -155,9 +168,23 @@ def cmd_plan(args: argparse.Namespace) -> int:
     return 0
 
 
+def should_show_banner(args: argparse.Namespace) -> bool:
+    """Return True when the terminal banner should be printed."""
+    if os.getenv("HAZARDWATCH_NO_BANNER"):
+        return False
+
+    if getattr(args, "json", False):
+        return False
+
+    return sys.stdout.isatty()
+
+
 def main(argv: List[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if should_show_banner(args):
+        print(IMH_BANNER)
 
     if args.command == "search":
         return cmd_search(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,3 +68,35 @@ def test_plan_json_output(capsys):
     assert rc == 0
     assert payload["workflow"] == "scene-discovery"
     assert len(payload["steps"]) >= 3
+
+
+def test_banner_shows_for_tty_non_json(monkeypatch, capsys):
+    monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+
+    rc = cli.main(["sources"])
+
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "InstaHazard Maps CLI" in output
+
+
+def test_banner_hidden_for_json_output(monkeypatch, capsys):
+    monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+
+    rc = cli.main(["plan", "--json"])
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert rc == 0
+    assert payload["workflow"] == "scene-discovery"
+
+
+def test_banner_can_be_disabled_with_env(monkeypatch, capsys):
+    monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+    monkeypatch.setenv("HAZARDWATCH_NO_BANNER", "1")
+
+    rc = cli.main(["sources"])
+
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "InstaHazard Maps CLI" not in output


### PR DESCRIPTION
### Motivation
- Provide a Copilot/Gemini-style branded startup graphic for interactive CLI users while keeping machine and CI workflows unaffected.
- Ensure the banner does not interfere with machine-readable output or non-interactive scripts by providing suppression logic and an explicit opt-out.

### Description
- Add a new `IMH_BANNER` ASCII art constant and print it at CLI startup in `main()` when appropriate. 
- Implement `should_show_banner()` to suppress the banner for `--json` output and when `HAZARDWATCH_NO_BANNER` is set, and to only show on TTYs via `sys.stdout.isatty()`.
- Document the banner behavior in `README.md` and append a log/idea entry in `AGENTS.md`.
- Add unit tests exercising banner behavior (`test_banner_shows_for_tty_non_json`, `test_banner_hidden_for_json_output`, `test_banner_can_be_disabled_with_env`) in `tests/test_cli.py`.

### Testing
- Ran `pytest -q` and all tests passed (10 passed).
- Added unit tests that verify banner appears on a TTY and is suppressed for `--json` and when `HAZARDWATCH_NO_BANNER` is set, and those tests succeed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58bb341f08327b850d5859a9ef336)